### PR TITLE
Remove deprecated cli switch

### DIFF
--- a/docs/getting-started/index.mdx
+++ b/docs/getting-started/index.mdx
@@ -42,13 +42,13 @@ topaz install
 You can use the CLI to create a configuration file:
 
 ```shell
-topaz configure -n <policy-name> -d -s -r <resource-url>
+topaz configure -n <policy-name> -d -r <resource-url>
 ```
 
 For example, this command creates a configuration file for the sample Todo policy image.
 
 ```shell
-topaz configure -d -s -r ghcr.io/aserto-policies/policy-todo-rebac:latest -n policy-todo
+topaz configure -d -r ghcr.io/aserto-policies/policy-todo-rebac:latest -n policy-todo
 ```
 
 The configuration file is generated in `$HOME/.config/topaz/cfg`.


### PR DESCRIPTION
```sh
% topaz configure -d -s -r ghcr.io/aserto-policies/policy-todo-rebac:latest -n policy-todo
Usage: topaz configure --force

configure topaz service

Flags:
  -h, --help                         Show context-sensitive help.
  -N, --no-check                     disable local container status check ($TOPAZ_NO_CHECK)

  -n, --policy-name=STRING           policy name
  -l, --local-policy-image=STRING    local policy image name
  -r, --resource=STRING              resource url
  -p, --stdout                       generated configuration is printed to stdout but not saved
  -d, --edge-directory               enable edge directory
  -f, --force                        forcefully create configuration

topaz: error: unknown flag -s, did you mean one of "-h", "-N", "-n", "-l", "-r", "-p", "-d", "-f"?

% topaz configure -d -r ghcr.io/aserto-policies/policy-todo-rebac:latest -n policy-todo 
>>> configure policy
policy name: policy-todo
```